### PR TITLE
Update @actions/core

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "test": "jest"
   },
   "devDependencies": {
-    "@actions/core": "^1.5.0",
+    "@actions/core": "^1.10.0",
     "@types/glob": "^7.1.4",
     "@types/jest": "^27.0.2",
     "@types/node": "^16.9.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,7 +1,7 @@
 lockfileVersion: 5.4
 
 specifiers:
-  '@actions/core': ^1.5.0
+  '@actions/core': ^1.10.0
   '@types/glob': ^7.1.4
   '@types/jest': ^27.0.2
   '@types/node': ^16.9.4


### PR DESCRIPTION
@actions/core needs to be updated or setOutput will break after May 31, 2023. See: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/