### PR TITLE
Add error annotation support

### DIFF
--- a/github-action/index.ts
+++ b/github-action/index.ts
@@ -27,6 +27,24 @@ async function run() {
     const results = await validateDirectory({ yamlVersion }, rootPath, schemaMapping);
 
     if (results && results.length > 0) {
+        for (const result of results) {
+            for (const error of result.error) {
+                core.error(
+                    `${result.filePath}:${error.range.start.line + 1}:${error.range.start.character + 1}: ${
+                        error.message
+                    }`,
+                    {
+                        title: error.message,
+                        file: result.filePath,
+                        startLine: error.range.start.line,
+                        endLine: error.range.end.line,
+                        startColumn: error.range.start.character,
+                        endColumn: error.range.end.character,
+                    },
+                );
+            }
+        }
+
         core.setFailed(`${results.length} file(s) failed validation`);
         core.setOutput(
             'invalidFiles',


### PR DESCRIPTION
GitHub actions now support that you can annotate errors in the PR diff. This can be implemented with `core.error`.

I'm not sure how I can test if this works as intended. I based the implementation on:

Docs: https://github.com/actions/toolkit/tree/main/packages/core#annotations
Code example: https://github.com/DavidAnson/markdownlint-cli2-action/blob/2418512f7ca2c0238e3ad5b21601d93f78d91c82/markdownlint-cli2-action.js#L31.
Result example: https://github.com/golangci/golangci-lint-action/blob/master/static/annotations.png

