### PR TITLE
Update action to use node16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -11,7 +11,7 @@ outputs:
   invalidFiles:
     description: List of files which failed the validation.
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'github-action/dist/index.js'
 branding:
   color: green


### PR DESCRIPTION
Update to use node16, since node12 is deprecated.

https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/