### PR TITLE
Fix line-numbers for error annotations

### DIFF
--- a/github-action/index.ts
+++ b/github-action/index.ts
@@ -36,8 +36,8 @@ async function run() {
                     {
                         title: error.message,
                         file: result.filePath,
-                        startLine: error.range.start.line,
-                        endLine: error.range.end.line,
+                        startLine: error.range.start.line + 1,
+                        endLine: error.range.end.line + 1,
                         startColumn: error.range.start.character,
                         endColumn: error.range.end.character,
                     },


### PR DESCRIPTION
The documentation says the line-numbers are 0-indexed, However, in practice they are 1-index. Other than that, it worked great.